### PR TITLE
Adapt deployment process to our branch protection rules

### DIFF
--- a/.make_release.sh
+++ b/.make_release.sh
@@ -53,6 +53,7 @@ git add CHANGELOG.md
 
 echo 'Committing version bump...'
 git commit -m ":bookmark: Commit version v$new_version"
+echo 'Pushing version bump...'
 git push
 
 echo "1st step done. Now create a pull request to the upstream repository and ask a maintainer to create the tag for you."

--- a/.make_release.sh
+++ b/.make_release.sh
@@ -54,9 +54,5 @@ git add CHANGELOG.md
 echo 'Committing version bump...'
 git commit -m ":bookmark: Commit version v$new_version"
 git push
-echo 'Create and push tag...'
-git tag -a "v$new_version" -m "Version v$new_version"
-git push origin "v$new_version"
 
-echo "Done. Version $new_version is now released on GitHub (and soon on PyPi, etc.)."
-echo -e "Congratulations \U2728"
+echo "1st step done. Now create a pull request to the upstream repository and ask a maintainer to create the tag for you."

--- a/.tag_release.sh
+++ b/.tag_release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Tag a new release, prepared by .make_release.sh .
+# This needs to be run on the main repository.
+
+new_version=`poetry version | sed 's/fotoobo \(.*\)/\1/'`
+
+echo 'Create and push tag...'
+git tag -a "v$new_version" -m "Version v$new_version"
+git push origin "v$new_version"
+
+echo "Done. Version $new_version is now released on GitHub (and soon on PyPi, etc.)."
+echo -e "Congratulations \U2727"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ For examples and guidelines see [https://keepachangelog.com/](https://keepachang
 
 ## [Released]
 
+## [0.4.3] - 2023-03-02
+
+### Added
+
+- GitHub actions to automatically deploy to (Test-)PyPi and create a GitHub release
+
 
 ## [0.4.2] - 2023-03-02
 

--- a/fotoobo/__init__.py
+++ b/fotoobo/__init__.py
@@ -5,4 +5,4 @@ This is fotoobo, the mighty Fortinet toolbox for managing your Fortinet environm
 to be extendable to your needs. It's most likely the swiss army knife for Fortinet infrastructure.
 """
 
-__version__: str = "0.4.2"
+__version__: str = "0.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fotoobo"
-version = "0.4.2"
+version = "0.4.3"
 description = "The awesome Fortinet Toolbox"
 authors = ["Patrik Spiess <patrik.spiess@mgb.ch>"]
 readme = "README.md"


### PR DESCRIPTION
- create .tag_release.sh script to be run from the upstream repo
- modify .make_release.sh to only contain stuff, that can be done on a forked repository
- bump release 0.4.3