### PR TITLE
Add the possibility to save a config file in ~/.config/fotoobo.yaml (for *nix)

### DIFF
--- a/docs/source/usage/configuration.rst
+++ b/docs/source/usage/configuration.rst
@@ -12,8 +12,13 @@ fotoobo.yaml
 ^^^^^^^^^^^^
 
 fotoobo reads its configuration from a global configuration file, usually named `fotoobo.yaml`. If
-you do not explicitly set a file (with the command line option `-c` ) fotoobo searches for the file
-`fotoobo.yaml` in the current working directory.
+you do not explicitly set a file (with the command line option `-c` ) fotoobo searches at the following
+locations for a file named `fotoobo.yaml` (in the order given here):
+
+1. In the current working directory.
+2. In `$HOME/.config/`
+
+It will take the first file given and stop searching for other files.
 
 If you do not specify a configuration file and fotoobo does not find it in the local directory it
 runs with default settings which are referenced below.

--- a/docs/source/usage/configuration.rst
+++ b/docs/source/usage/configuration.rst
@@ -15,7 +15,7 @@ fotoobo reads its configuration from a global configuration file, usually named 
 you do not explicitly set a file (with the command line option `-c` ) fotoobo searches at the following
 locations for a file named `fotoobo.yaml` (in the order given here):
 
-1. In the current working directory.
+1. In the current working directory
 2. In `$HOME/.config/`
 
 It will take the first file given and stop searching for other files.

--- a/fotoobo/cli/main.py
+++ b/fotoobo/cli/main.py
@@ -8,7 +8,7 @@ Caution: Use docstrings with care as they are used to print help texts on any co
 """
 import logging
 import sys
-from typing import Optional
+from typing import Optional, Union
 
 import typer
 
@@ -37,8 +37,8 @@ def version_callback(value: bool) -> None:
 @app.callback()
 def callback(  # pylint: disable=too-many-arguments
     context: typer.Context,
-    config_file: str = typer.Option(
-        "fotoobo.yaml",
+    config_file: Union[str, None] = typer.Option(
+        None,
         "--config",
         "-c",
         help="The fotoobo configuration file",

--- a/fotoobo/helpers/config.py
+++ b/fotoobo/helpers/config.py
@@ -6,6 +6,7 @@ cli help system.
 If there are configuration options available in the global configuration file and also as a command
 line option, the command line option takes precedence over the global configuration file option.
 """
+import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Union
 
@@ -13,7 +14,7 @@ from fotoobo.helpers.files import load_yaml_file
 
 
 @dataclass(eq=False, order=False)
-class Config:  # pylint: disable=too-many-instance-attributes
+class Config:
     """
     This is the configuration dataclass for the global configuration options.
     First all the configuration options must be initialized.
@@ -25,13 +26,11 @@ class Config:  # pylint: disable=too-many-instance-attributes
     inventory_file: str = "inventory.yaml"
     logging: Union[Dict[str, Any], None] = None
     audit_logging: Union[Dict[str, Any], None] = None
-    log_file: str = ""
-    log_level: str = "INFO"
     no_logo: bool = False
     snmp_community: str = ""
     cli_info: Dict[str, Any] = field(default_factory=dict)
 
-    def load_configuration(self, config_file: str) -> None:
+    def load_configuration(self, config_file: Union[str, None]) -> None:
         """
         Load the global fotoobo configuration file. If the configuration file is not present it just
         will be ignored and all the options remain as they are.
@@ -42,22 +41,43 @@ class Config:  # pylint: disable=too-many-instance-attributes
         Args:
             config_file (str): fotoobo configuration file to load configuration from
         """
-        if loaded_config := load_yaml_file(config_file):
-            # We need a dict here
-            loaded_config = dict(loaded_config)
 
-            # then set the config options from file if set in file
-            self.backup_dir = loaded_config.get("backup_dir", self.backup_dir)
-            self.inventory_file = loaded_config.get("inventory", self.inventory_file)
+        # If no explicit config file has been given, search at the predefined places
+        if config_file is None:
+            fotoobo_yaml_in_dot_config = os.path.join(
+                os.path.expanduser("~"), ".config", "fotoobo.yaml"
+            )
 
-            if loaded_config.get("logging"):
-                self.logging = loaded_config["logging"]
+            # First we check whether there is a project fotoobo.yaml in the
+            # current working directory
+            if os.path.isfile("fotoobo.yaml"):
+                config_file = "fotoobo.yaml"
 
-            if loaded_config.get("audit_logging"):
-                self.audit_logging = loaded_config["audit_logging"]
+            # Second we check whether there is a user wide fotoobo.yaml in the .config folder
+            elif os.path.isfile(fotoobo_yaml_in_dot_config):
+                config_file = fotoobo_yaml_in_dot_config
 
-            self.no_logo = loaded_config.get("no_logo", self.no_logo)
-            self.snmp_community = loaded_config.get("snmp_community", self.snmp_community)
+            # If no config file can be found we rest with the defaults
+            else:
+                return
+
+        if config_file:
+            if loaded_config := load_yaml_file(config_file):
+                # We need a dict here
+                loaded_config = dict(loaded_config)
+
+                # then set the config options from file if set in file
+                self.backup_dir = loaded_config.get("backup_dir", self.backup_dir)
+                self.inventory_file = loaded_config.get("inventory", self.inventory_file)
+
+                if loaded_config.get("logging"):
+                    self.logging = loaded_config["logging"]
+
+                if loaded_config.get("audit_logging"):
+                    self.audit_logging = loaded_config["audit_logging"]
+
+                self.no_logo = loaded_config.get("no_logo", self.no_logo)
+                self.snmp_community = loaded_config.get("snmp_community", self.snmp_community)
 
 
 config = Config()

--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -1,9 +1,10 @@
 """
 Test the config helper
 """
-
+from typing import Callable, Union
 from unittest.mock import MagicMock
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from fotoobo.helpers.config import Config
@@ -12,26 +13,60 @@ from fotoobo.helpers.config import Config
 class TestConfig:
     """Test the config dataclass"""
 
-    @staticmethod
-    def test_config() -> None:
-        """test it"""
+    def test_config(self) -> None:
+        """test the default config settings"""
         config = Config()
         assert config.backup_dir == ""
         assert config.inventory_file == "inventory.yaml"
         assert not config.logging
         assert not config.audit_logging
-        assert config.log_file == ""
-        assert config.log_level == "INFO"
         assert not config.no_logo
 
-    @staticmethod
-    def test_load_configuration(monkeypatch: MonkeyPatch) -> None:
+    @pytest.mark.parametrize(
+        "config_file,isfile_mock,load_yaml_file_mock,expected_backup_dir",
+        (
+            pytest.param(
+                None,
+                MagicMock(return_value=False),
+                MagicMock(return_value=None),
+                "",
+                id="No config file given",
+            ),
+            pytest.param(
+                "test/fotoobo.yaml",
+                MagicMock(return_value=True),
+                MagicMock(return_value={"backup_dir": "test1", "logging": {"enabled": True}}),
+                "test1",
+                id="Custom fotoobo.yaml",
+            ),
+            pytest.param(
+                None,
+                lambda file: file == "fotoobo.yaml",
+                MagicMock(return_value={"backup_dir": "test2", "audit_logging": {"enabled": True}}),
+                "test2",
+                id="Use fotoobo.yaml in current directory",
+            ),
+            pytest.param(
+                None,
+                lambda file: file != "fotoobo.yaml",
+                MagicMock(return_value={"backup_dir": "test3"}),
+                "test3",
+                id="Use fotoobo.yaml in .config/fotoobo.yaml",
+            ),
+        ),
+    )
+    # pylint: disable=too-many-arguments
+    def test_load_configuration(
+        self,
+        config_file: Union[str, None],
+        isfile_mock: Union[MagicMock, Callable[[str], bool]],
+        load_yaml_file_mock: MagicMock,
+        expected_backup_dir: str,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
         """test load configuration from file"""
-        monkeypatch.setattr("fotoobo.helpers.files.os.path.isfile", MagicMock(return_value=True))
-        monkeypatch.setattr(
-            "fotoobo.helpers.config.load_yaml_file", MagicMock(return_value={"backup_dir": "test"})
-        )
+        monkeypatch.setattr("fotoobo.helpers.files.os.path.isfile", isfile_mock)
+        monkeypatch.setattr("fotoobo.helpers.config.load_yaml_file", load_yaml_file_mock)
         config = Config()
-        assert config.backup_dir == ""
-        config.load_configuration("dummy")
-        assert config.backup_dir == "test"
+        config.load_configuration(config_file)
+        assert config.backup_dir == expected_backup_dir

--- a/tests/helpers/test_log.py
+++ b/tests/helpers/test_log.py
@@ -8,10 +8,10 @@ from logging.handlers import RotatingFileHandler, SysLogHandler
 from typing import List, Type
 from unittest.mock import MagicMock
 
+from syslog import LOG_USER
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from rich.logging import RichHandler
-from syslog import LOG_USER
 
 from fotoobo.helpers.config import Config
 from fotoobo.helpers.log import Log, SysLogFormatter
@@ -61,7 +61,8 @@ class TestSysLogFormatter:
                     exc_info=None,
                     args=None,
                 ),
-                "<15>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - username=dummy_user test_message",
+                "<15>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - "
+                "username=dummy_user test_message",
                 id="debug log",
             ),
             pytest.param(
@@ -74,7 +75,8 @@ class TestSysLogFormatter:
                     exc_info=None,
                     args=None,
                 ),
-                "<14>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - username=dummy_user test_message",
+                "<14>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - "
+                "username=dummy_user test_message",
                 id="info log",
             ),
             pytest.param(
@@ -87,7 +89,8 @@ class TestSysLogFormatter:
                     exc_info=None,
                     args=None,
                 ),
-                "<12>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - username=dummy_user test_message",
+                "<12>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - "
+                "username=dummy_user test_message",
                 id="warning log",
             ),
             pytest.param(
@@ -100,7 +103,8 @@ class TestSysLogFormatter:
                     exc_info=None,
                     args=None,
                 ),
-                "<11>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - username=dummy_user test_message",
+                "<11>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - "
+                "username=dummy_user test_message",
                 id="error log",
             ),
             pytest.param(
@@ -113,7 +117,8 @@ class TestSysLogFormatter:
                     exc_info=None,
                     args=None,
                 ),
-                "<10>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - username=dummy_user test_message",
+                "<10>1 1970-01-01T%s:00:00%s fotoobo dummy.host 3456 - - "
+                "username=dummy_user test_message",
                 id="critical log",
             ),
         ],
@@ -123,7 +128,6 @@ class TestSysLogFormatter:
         syslog_formatter: SysLogFormatter,
         log_record: logging.LogRecord,
         expected_string: str,
-        monkeypatch: MonkeyPatch,
     ) -> None:
         """
         Test the format() method
@@ -148,7 +152,8 @@ class TestSysLogFormatter:
 
     def test_format_with_unknown_loglevel(self, syslog_formatter: SysLogFormatter) -> None:
         """
-        Test the format() method, when an unknown level is given. It should raise a NotImplementedError in this case
+        Test the format() method, when an unknown level is given.
+        It should raise a NotImplementedError in this case
 
         Args:
             syslog_formatter:
@@ -232,6 +237,7 @@ class TestLog:
             ),
         ),
     )
+    # pylint: disable=too-many-arguments
     def test_configure_logging(
         self,
         config: Config,


### PR DESCRIPTION
closes #32 

Still has the issue, that this will (probably) not work for Windows, and unsure whether this matches the Mac's configuration location convention.