### PR TITLE
Issue 67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For examples and guidelines see [https://keepachangelog.com/](https://keepachang
 ### Changed
 
 - Fix ordering of syslog message to comply with RFC5424
+- Fix path handling with jinja2 templates (now support relative and absolute paths)
 
 
 

--- a/fotoobo/helpers/files.py
+++ b/fotoobo/helpers/files.py
@@ -1,12 +1,12 @@
 """
 Some helper functions for file manipulation.
 """
-
 import json
 import logging
 import os
 import re
 from ftplib import FTP, FTP_TLS
+from pathlib import Path
 from typing import Any, Dict, List, Union
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -185,8 +185,10 @@ def save_with_template(data: Dict[Any, Any], template_file: str, output_file: st
         output_file (str): The file to write the output to
     """
     log.debug("template_file is: %s", template_file)
-    template_env = jinja2.Environment(loader=jinja2.FileSystemLoader("./"), trim_blocks=True)
-    template = template_env.get_template(template_file)
+    template_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(Path(template_file).parent), trim_blocks=True
+    )
+    template = template_env.get_template(Path(template_file).name)
     output = template.render(data)
     with open(output_file, "w", encoding="UTF-8") as file:
         file.write(output)

--- a/fotoobo/helpers/files.py
+++ b/fotoobo/helpers/files.py
@@ -179,8 +179,7 @@ def save_with_template(data: Dict[Any, Any], template_file: str, output_file: st
     Args:
         data (Dict[Any, Any]): The data used in the template
 
-        template_file (str): Filename of the Jinja2 template file. The path to the template_file
-        is always a relative path (at the moment). Absolute paths are not supported.
+        template_file (str): Filename of the Jinja2 template file
 
         output_file (str): The file to write the output to
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 """The pytest global fixtures"""
 
+from pathlib import Path
+
+import _pytest
 import pytest
 
 
 @pytest.fixture(scope="session")
-def temp_dir(tmp_path_factory):  # type: ignore # (it's a pathlib.Path object)
+def temp_dir(tmp_path_factory: _pytest.tmpdir.TempPathFactory) -> Path:
     """creates and maintains a session temp directory"""
     return tmp_path_factory.mktemp("tests_")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@
 
 from pathlib import Path
 
-import _pytest
 import pytest
+from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")
-def temp_dir(tmp_path_factory: _pytest.tmpdir.TempPathFactory) -> Path:
+def temp_dir(tmp_path_factory: TempPathFactory) -> Path:
     """creates and maintains a session temp directory"""
     return tmp_path_factory.mktemp("tests_")


### PR DESCRIPTION
I fixed the path handling when using jinja2 templates. It now supports absolute and relative paths. And by the way I also used Path from the pathlib library instead of os.path. Maybe we should change all path handling to pathlib as it seems to be more intuitive. For examples see: https://medium.com/@ageitgey/python-3-quick-tip-the-easy-way-to-deal-with-file-paths-on-windows-mac-and-linux-11a072b58d5f

Additionally I also updated the typing in the tests temp dir fixtrure which was ignore before.

closes #67 