### PR TITLE
:bookmark: Commit version v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ For examples and guidelines see [https://keepachangelog.com/](https://keepachang
 
 ## [Unreleased]
 
+
+## [0.7.0] - 2023-04-06
+
 ### Added
 
-- Argument `backup_dir` in CLI command `fgt backup`
+- Option `backup_dir` in CLI command `fgt backup`
 - CLI command `fgt config info` to display information from FortiGate configuration file(s)
 
 ### Changed

--- a/fotoobo/__init__.py
+++ b/fotoobo/__init__.py
@@ -5,4 +5,4 @@ This is fotoobo, the mighty Fortinet toolbox for managing your Fortinet environm
 to be extendable to your needs. It's most likely the swiss army knife for Fortinet infrastructure.
 """
 
-__version__: str = "0.6.1"
+__version__: str = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fotoobo"
-version = "0.6.1"
+version = "0.7.0"
 description = "The awesome Fortinet Toolbox"
 authors = ["Patrik Spiess <patrik.spiess@mgb.ch>", "Lukas Murer-Jäckle <lukas.murer@mgb.ch>"]
 readme = "README.md"


### PR DESCRIPTION
## [0.7.0] - 2023-04-06

### Added

- Option `backup_dir` in CLI command `fgt backup`
- CLI command `fgt config info` to display information from FortiGate configuration file(s)

### Changed

- Update getting started guide
- Fix ordering of syslog message to comply with RFC5424
- Fix path handling with jinja2 templates (now support relative and absolute paths)

### Removed

- Global option `backup_dir` in fotoobo.yaml
