### PR TITLE
Release version 0.9.0 of fotoobo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ For examples and guidelines see [https://keepachangelog.com/](https://keepachang
 
 # [Unreleased]
 
+
+# [Released]
+
+## [0.9.0] - 2023-04-23
+
 ### Added
 
 - It is now possible to use a custom CA to verify the connections to your Fortinet devices
@@ -12,11 +17,9 @@ For examples and guidelines see [https://keepachangelog.com/](https://keepachang
 
 ### Changed
 
-- Command `fotoobo fmg assign` now lets you to specify which global policy to assign
+- Command `fotoobo fmg assign` now lets you specify which global policy to assign
 - Changed the order of arguments in `fotoobo fmg post` and made host optional with "fmg" as default.
 
-
-# [Released]
 
 ## [0.8.0] - 2023-04-13
 

--- a/fotoobo/__init__.py
+++ b/fotoobo/__init__.py
@@ -5,4 +5,4 @@ This is fotoobo, the mighty Fortinet toolbox for managing your Fortinet environm
 to be extendable to your needs. It's most likely the swiss army knife for Fortinet infrastructure.
 """
 
-__version__: str = "0.8.0"
+__version__: str = "0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fotoobo"
-version = "0.8.0"
+version = "0.9.0"
 description = "The awesome Fortinet Toolbox"
 authors = ["Patrik Spiess <patrik.spiess@mgb.ch>", "Lukas Murer-Jäckle <lukas.murer@mgb.ch>"]
 readme = "README.md"


### PR DESCRIPTION
### Added

- It is now possible to use a custom CA to verify the connections to your Fortinet devices

### Changed

- Command `fotoobo fmg assign` now lets you specify which global policy to assign
- Changed the order of arguments in `fotoobo fmg post` and made host optional with "fmg" as default.