### PR TITLE
🐛 Fix KeyError on Result.print_result_as_table() with empty Response()

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,11 @@
 - Option `--smtp` for `fmg assign`
 - Method `inventory.get_item()` to only get one single item from the inventory
 
+### Fixed
+
+- Result.print_result_as_table() gives error with empty Response. Now it just prints an empty line
+if no results were pushed.
+
 ### Changed
 
 ### Removed


### PR DESCRIPTION
- Fix KeyError on Result.print_result_as_table() with empty Response()
- Improve testing for Results() class
- closes #151

## Problem

    >>> from fotoobo.helpers.result import Result
    >>> result = Result()
    >>> result.print_result_as_table()
    
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File ".../fotoobo/helpers/result.py", line 187, in print_result_as_table
        self.print_table_raw(data, headers, auto_header, title)
      File ".../fotoobo/helpers/result.py", line 205, in print_table_raw
        if not (isinstance(data, list) and isinstance(data[0], dict)):
    IndexError: list index out of range
    >>> 


## After the fix

    >>> from fotoobo.helpers.result import Result
    >>> result = Result()
    >>> result.print_result_as_table()
    
    >>> 