### PR TITLE
👔 `fortimanager.post()` now returns list of errors instead of just th…

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,9 +1,11 @@
 ### Added
 
-- Option `--smtp` for `fmg assign`
+- Option `--smtp` for `fmg assign` and `fmg_post`
 - Method `inventory.get_item()` to only get one single item from the inventory
 
 ### Changed
+
+- `fortimanager.post()` now returns list of errors instead of just the number of errors
 
 ### Removed
 

--- a/fotoobo/fortinet/fortimanager.py
+++ b/fotoobo/fortinet/fortimanager.py
@@ -268,7 +268,7 @@ class FortiManager(Fortinet):
         self.session_key = ""
         return response.status_code
 
-    def post(self, adom: str, payloads: Any) -> int:
+    def post(self, adom: str, payloads: Any) -> List[str]:
         """
         POST method to FortiManager.
 
@@ -286,7 +286,9 @@ class FortiManager(Fortinet):
         # if payload is a dict convert it to a list with one dict in it.
         if isinstance(payloads, dict):
             payloads = [payloads]
-        errors = 0
+
+        results = []
+
         for payload in payloads:
             for i, _ in enumerate(payload["params"]):
                 # Here we have to replace the {adom} in the URL entry:
@@ -302,9 +304,13 @@ class FortiManager(Fortinet):
             for result in response.json()["result"]:
                 if result["status"]["code"] != 0:
                     log.error("%s: %s", result["status"]["message"], result["url"])
-                    errors += 1
+                    results.append(
+                        f"{result['status']['message']}: "
+                        f"{result['url']} "
+                        f"(code: {result['status']['code']})"
+                    )
 
-        return errors
+        return results
 
     def wait_for_task(self, task_id: int, timeout: int = 60) -> List[Any]:
         """

--- a/tests/cli/fmg/test_cli_fmg_main.py
+++ b/tests/cli/fmg/test_cli_fmg_main.py
@@ -36,5 +36,5 @@ def test_cli_app_fmg_post_help() -> None:
     assert result.exit_code == 0
     arguments, options, commands = parse_help_output(result.stdout)
     assert set(arguments) == {"file", "adom", "host"}
-    assert options == {"-h", "--help"}
+    assert options == {"-h", "--help", "-s", "--smtp"}
     assert not commands

--- a/tests/fortinet/test_fortimanager.py
+++ b/tests/fortinet/test_fortimanager.py
@@ -367,15 +367,15 @@ class TestFortiManager:
         )
 
     @staticmethod
-    def test_set_single(monkeypatch: MonkeyPatch) -> None:
-        """Test fmg set with a single dict"""
+    def test_post_single(monkeypatch: MonkeyPatch) -> None:
+        """Test fmg post with a single dict"""
         monkeypatch.setattr(
             "fotoobo.fortinet.fortinet.requests.Session.post",
             MagicMock(
                 return_value=ResponseMock(json={"result": [{"status": {"code": 0}}]}, status=200)
             ),
         )
-        assert FortiManager("host", "", "").post("ADOM", {"params": [{"url": "{adom}"}]}) == 0
+        assert not FortiManager("host", "", "").post("ADOM", {"params": [{"url": "{adom}"}]})
         requests.Session.post.assert_called_with(  # type:ignore
             "https://host:443/jsonrpc",
             headers=None,
@@ -385,15 +385,15 @@ class TestFortiManager:
         )
 
     @staticmethod
-    def test_set_multiple(monkeypatch: MonkeyPatch) -> None:
-        """Test fmg set with a list of dicts"""
+    def test_post_multiple(monkeypatch: MonkeyPatch) -> None:
+        """Test fmg post with a list of dicts"""
         monkeypatch.setattr(
             "fotoobo.fortinet.fortinet.requests.Session.post",
             MagicMock(
                 return_value=ResponseMock(json={"result": [{"status": {"code": 0}}]}, status=200)
             ),
         )
-        assert FortiManager("host", "", "").post("ADOM", [{"params": [{"url": "{adom}"}]}]) == 0
+        assert not FortiManager("host", "", "").post("ADOM", [{"params": [{"url": "{adom}"}]}])
         requests.Session.post.assert_called_with(  # type:ignore
             "https://host:443/jsonrpc",
             headers=None,
@@ -403,15 +403,15 @@ class TestFortiManager:
         )
 
     @staticmethod
-    def test_set_single_global(monkeypatch: MonkeyPatch) -> None:
-        """Test fmg set with a single dict"""
+    def test_post_single_global(monkeypatch: MonkeyPatch) -> None:
+        """Test fmg post with a single dict"""
         monkeypatch.setattr(
             "fotoobo.fortinet.fortinet.requests.Session.post",
             MagicMock(
                 return_value=ResponseMock(json={"result": [{"status": {"code": 0}}]}, status=200)
             ),
         )
-        assert FortiManager("host", "", "").post("global", {"params": [{"url": "{adom}"}]}) == 0
+        assert not FortiManager("host", "", "").post("global", {"params": [{"url": "{adom}"}]})
         requests.Session.post.assert_called_with(  # type:ignore
             "https://host:443/jsonrpc",
             headers=None,
@@ -421,8 +421,8 @@ class TestFortiManager:
         )
 
     @staticmethod
-    def test_set_response_error(monkeypatch: MonkeyPatch) -> None:
-        """Test fmg set with en error in the response"""
+    def test_post_response_error(monkeypatch: MonkeyPatch) -> None:
+        """Test post set with en error in the response"""
         monkeypatch.setattr(
             "fotoobo.fortinet.fortinet.requests.Session.post",
             MagicMock(
@@ -434,7 +434,9 @@ class TestFortiManager:
                 )
             ),
         )
-        assert FortiManager("host", "", "").post("ADOM", [{"params": [{"url": "{adom}"}]}]) == 1
+        assert FortiManager("host", "", "").post("ADOM", [{"params": [{"url": "{adom}"}]}]) == [
+            "dummy: dummy (code: 444)"
+        ]
         requests.Session.post.assert_called_with(  # type:ignore
             "https://host:443/jsonrpc",
             headers=None,
@@ -444,8 +446,8 @@ class TestFortiManager:
         )
 
     @staticmethod
-    def test_set_http_error(monkeypatch: MonkeyPatch) -> None:
-        """Test fmg set with an error in the response"""
+    def test_post_http_error(monkeypatch: MonkeyPatch) -> None:
+        """Test fmg post with an error in the response"""
         monkeypatch.setattr(
             "fotoobo.fortinet.fortinet.requests.Session.post",
             MagicMock(return_value=ResponseMock(json={}, status=444)),

--- a/tests/tools/fmg/test_post.py
+++ b/tests/tools/fmg/test_post.py
@@ -1,8 +1,8 @@
 """Test fmg tools post"""
 
 
-from unittest.mock import MagicMock
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -43,14 +43,14 @@ def test_post(monkeypatch: MonkeyPatch) -> None:
         "fotoobo.tools.fmg.main.load_json_file", MagicMock(return_value={"dummy": "dummy"})
     )
     monkeypatch.setattr(
-        "fotoobo.fortinet.fortimanager.FortiManager.post", MagicMock(return_value=None)
+        "fotoobo.fortinet.fortimanager.FortiManager.post", MagicMock(return_value=["dummy_message"])
     )
-    post(file=Path("dummy_file"), adom="dummy_adom", host="test_fmg")
-    assert True
+    result = post(file=Path("dummy_file"), adom="dummy_adom", host="test_fmg")
+    assert result.get_messages("test_fmg")[0]["message"] == "dummy_message"
 
 
 def test_post_exception_empty_payload_file(monkeypatch: MonkeyPatch) -> None:
-    """Test POST with exception when device is not defined"""
+    """Test POST with exception when there is no data in the payload file"""
     monkeypatch.setattr("fotoobo.tools.fmg.main.load_json_file", MagicMock(return_value=[]))
     with pytest.raises(GeneralWarning, match=r"there is no data in the given file"):
         post(file=Path("dummy_file"), adom="dummy_adom", host="dummy_host")


### PR DESCRIPTION
- `fortimanager.post()` now returns list of errors instead of just the number of errors
- Improved testing for `fmg post`
- Improved login/logout handling for `fmg assign` and `fmg post`. It now can reuse existing FortiManager session.
- Renamed set to post (this was done earlier but we forgot to change it everywere)
- Add `--smtp` option to `fmg post`
- Closes #40

*Hey, don't complain about the commit message. I accidently refered to the wrong issue and do not know how to change it.*