### PR TITLE
Enhance create dir() in the files helper #163

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -2,5 +2,7 @@
 
 ### Changed
 
+- Enhance create_dir() in files helper
+
 ### Removed
 

--- a/fotoobo/helpers/files.py
+++ b/fotoobo/helpers/files.py
@@ -11,6 +11,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 import yaml
 
+
 from fotoobo.exceptions import GeneralError
 
 log = logging.getLogger("fotoobo")
@@ -21,14 +22,14 @@ def create_dir(directory: Path) -> None:
     Try to create a given directory if it does not exist.
 
     Args:
-        directory (Path): The directory to create (in case it not already exists)
+        directory: The directory to create (in case it not already exists)
 
     Raises:
-        DirectoryError: Error with message
+        OSError: Error with message
     """
     if not directory.is_dir():
         try:
-            directory.mkdir()
+            directory.mkdir(parents=True)
         except OSError as err:
             raise GeneralError(f"Unable to create directory {directory}") from err
 

--- a/tests/helpers/test_files.py
+++ b/tests/helpers/test_files.py
@@ -312,9 +312,8 @@ def test_create_dir_for_existing_directory(temp_dir: Path) -> None:
 def test_create_dir_for_sub_sub_directory(temp_dir: Path) -> None:
     """Test create_dir when trying to create a sub, subdirectory"""
     directory = temp_dir / "test_dir_3" / "test_dir_4"
-    assert not directory.is_dir()
-    with pytest.raises(GeneralError, match=r"Unable to create directory .*/test_dir_3/test_dir_4"):
-        create_dir(directory)
+    create_dir(directory)
+    assert directory.is_dir()
 
 
 def test_create_dir_with_os_error(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Use `parents=True` to also create parent directories when they do not exist
`exist_ok=True` is not needed because we first check if directory already exists.
closes #163 