### PR TITLE
Fix EMS license expiry evaluation

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -6,3 +6,6 @@
 
 - `fmg get devices` also shows ha nodes if device is a cluster
 
+### Fixed
+
+- Better handling of EMS license expiry evaluation

--- a/fotoobo/tools/ems/monitor.py
+++ b/fotoobo/tools/ems/monitor.py
@@ -221,12 +221,14 @@ def license(host: str) -> Result[Dict[str, Any]]:  # pylint: disable=redefined-b
     data = {}
     data["data"] = dict(response.json()["data"])
 
+    license_expiry_days = 0
     for lic in data["data"]["licenses"]:
-        if lic["type"] == "ztna":
-            log.debug("license expiry: %s", lic["expiry_date"])
-            license_expiry = datetime.strptime(lic["expiry_date"], "%Y-%m-%dT%H:%M:%S")
-            license_expiry_days = int((license_expiry - datetime.now()).days)
-            log.debug("days to license expiry: %s", license_expiry_days)
+        log.debug("license expiry for '%s': '%s'", lic["type"], lic["expiry_date"])
+        license_expiry = datetime.strptime(lic["expiry_date"], "%Y-%m-%dT%H:%M:%S")
+        expiry_days = int((license_expiry - datetime.now()).days)
+        if expiry_days < license_expiry_days or license_expiry_days == 0:
+            license_expiry_days = expiry_days
+    log.debug("days to license expiry: %s", license_expiry_days)
 
     data["fotoobo"] = {}
     data["fotoobo"]["license_expiry_days"] = license_expiry_days

--- a/fotoobo/tools/ems/monitor.py
+++ b/fotoobo/tools/ems/monitor.py
@@ -222,7 +222,7 @@ def license(host: str) -> Result[Dict[str, Any]]:  # pylint: disable=redefined-b
     data["data"] = dict(response.json()["data"])
 
     for lic in data["data"]["licenses"]:
-        if lic["type"] == "fabric_agent":
+        if lic["type"] == "ztna":
             log.debug("license expiry: %s", lic["expiry_date"])
             license_expiry = datetime.strptime(lic["expiry_date"], "%Y-%m-%dT%H:%M:%S")
             license_expiry_days = int((license_expiry - datetime.now()).days)

--- a/fotoobo/tools/ems/monitor.py
+++ b/fotoobo/tools/ems/monitor.py
@@ -191,13 +191,13 @@ def license(host: str) -> Result[Dict[str, Any]]:  # pylint: disable=redefined-b
     with calculated and interesting values. All the enriched values are in the key "fotoobo" in the
     returned dict:
 
-        - {{ fotoobo.[MODULE]_usage }}          License usage in percent by MODULE where MODULE is
-            one of:
+        - {{ fotoobo.[MODULE]_usage }}
+            License usage in percent by MODULE where MODULE is one of:
                 - fabric_agent
-                - ztna
-                - epp
                 - sandbox_cloud
                 - chromebook
+                - ztna
+                - epp
                 - sase
                 - ztna_user
                 - epp_user


### PR DESCRIPTION
Initially we calculated the EMS license expiry with the 'fabric_agent' entry which failed with a traceback when 'fabric_agent' was not present in the EMS licenses.

Now we iterate over all licenses available and take the one with the shortest expiry date.