### PR TITLE
🩹 Fix slicing on secrets output

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -9,3 +9,4 @@
 ### Fixed
 
 - Better handling of EMS license expiry evaluation
+- Fix slicing on secrets output

--- a/fotoobo/cli/main.py
+++ b/fotoobo/cli/main.py
@@ -6,6 +6,7 @@ more than a few subcommands.
 
 Caution: Use docstrings with care as they are used to print help texts on any command.
 """
+
 # pylint: disable=anomalous-backslash-in-string
 import logging
 import os
@@ -103,7 +104,7 @@ def callback(  # pylint: disable=too-many-arguments
         if attr in ["audit_logging", "logging", "vault"] and getattr(config, attr):
             for sub_attr, value in getattr(config, attr).items():
                 if attr == "vault" and sub_attr in ["role_id", "secret_id"]:
-                    value = f"{value[:4]}...{value[-5:-1]}"
+                    value = f"{value[:4]}...{value[-4:]}"
 
                 log.debug("Option '%s.%s' is '%s'", attr, sub_attr, value)
 

--- a/fotoobo/helpers/vault.py
+++ b/fotoobo/helpers/vault.py
@@ -73,8 +73,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
         log.debug("vault_client_ssl_verify: '%s'", self.ssl_verify)
         log.debug("vault_client_namespace: '%s'", self.namespace)
         log.debug("vault_client_data_path: '%s'", self.data_path)
-        log.debug("vault_client_role_id: '%s...%s'", self.role_id[:4], self.role_id[-5:-1])
-        log.debug("vault_client_secret_id: '%s...%s'", self.secret_id[:4], self.secret_id[-5:-1])
+        log.debug("vault_client_role_id: '%s...%s'", self.role_id[:4], self.role_id[-4:])
+        log.debug("vault_client_secret_id: '%s...%s'", self.secret_id[:4], self.secret_id[-4:])
         log.debug("vault_client_token_ttl_limit: '%s'", self.token_ttl_limit)
 
         if token_file:
@@ -200,7 +200,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
 
             if response.ok:
                 log.debug("Vault token is valid for '%s' seconds", response.json()["data"]["ttl"])
-                log.debug("vault_client_token: '%s...%s'", self.token[:8], self.token[-5:-1])
+                log.debug("vault_client_token: '%s...%s'", self.token[:8], self.token[-4:])
                 if response.json()["data"]["ttl"] < self.token_ttl_limit:
                     log.debug("Invalidate token due to ttl limit")
                     self.token = ""


### PR DESCRIPTION
Shortened secrets should output the very last four characters. Due to a missunderstanding the last character was omited.
(I should have practiced it better during my CAS)

Closes nothing ;-)