### PR TITLE
📝 Add Hashicorp Vault as a mitigation of the unencrypted inventory risk

### DIFF
--- a/docs/source/developer/architecture/9_risks_technical_depths.rst
+++ b/docs/source/developer/architecture/9_risks_technical_depths.rst
@@ -56,6 +56,5 @@ There are several things done to mitigate this risk:
   not the first suggestion in the documentation.
 - The risk of exposing the inventory and how to minimize this risk is clearly stated in the
   documentation at :ref:`usage_inventory`.
-
-*Note: There are ideas about supporting HashiCorp Vault as storage backend for the credentials. If
-you want to support us there, please reach out to us on GitHub.*
+- To make the handling of sensitive data a bit safer you may store such data in a Hashicorp Vault
+  service which is documented here: :ref:`vault_service`.


### PR DESCRIPTION
I found some old information which might be updated.
The Risk of storing unenctrypted credentials/tokens is not that critical anymore becuase we now support Hashicorp Vault.
Not sure if we want to remove it at all. I'd rather leave it, because storing unencrypted credentials/tokens is still possible. Using the Hashicorp Vault servie is not enabled by default so ...