### PR TITLE
⬆️ Upgrade Jinja2 due to dependabot warning

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Upgrade black to ~24.03.0 due to dependabot warning
+- Upgrade jinja2 to ~3.1.4 due to dependabot warning
 - Upgrade pylint to ~3.1.0
 - Minor update of several dependencies
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -483,13 +483,13 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.4"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
-    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
 ]
 
 [package.dependencies]
@@ -849,7 +849,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1263,4 +1262,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0, <3.13"
-content-hash = "16b58b1f13dd27242b1aecddff64ba39b7929b3af6f484c909feaf12842067f7"
+content-hash = "cc34f5597dc6fe34db960832d4fb57d0014faf8748a04e3ba6488dbcebeea91b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ typer = "~0.6.0"
 rich = "~12.5.1"
 PyYAML = "~6.0.0"
 requests = "~2.31.0"
-Jinja2 = "~3.1.2"
+Jinja2 = "~3.1.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "~7.2.0"


### PR DESCRIPTION
Upgrade Jinja2 to fix 1 Dependabot alert in poetry.lock