### PR TITLE
⬆️ Upgared virtualenv due to dependabot warning

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -7,12 +7,11 @@
 - Add CLI command fgt get cmdb firewall service-group
 - Add the layers of fotoobo into the architecture documentation
 
-
 ### Changed
 
 - Fix some typing issues for Python3.8
 - Optimize imports in CLI module
-- Upgrade requests, jinja and pygount due to security issues and bugs
+- Upgrade requests, jinja, pygount and virtualenv due to security issues and bugs
 
 ### Removed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1340,14 +1340,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.2"
+version = "20.28.1"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.26.2-py3-none-any.whl", hash = "sha256:a624db5e94f01ad993d476b9ee5346fdf7b9de43ccaee0e0197012dc838a0e9b"},
-    {file = "virtualenv-20.26.2.tar.gz", hash = "sha256:82bf0f4eebbb78d36ddaee0283d43fe5736b53880b8a8cdcd37390a07ac3741c"},
+    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
+    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Upgrade virtualenv due to dependabot warning:

"
virtualenv before 20.26.6 allows command injection through the activation scripts for a virtual environment. Magic template strings are not quoted correctly when replacing.
"