### PR TITLE
:bookmark: Commit version v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ For unreleased changes see [WHATSNEW.md](WHATSNEW.md)
 
 # [Released]
 
+## [2.3.0] - 2025-05-07
+
+### Added
+
+- Add generic api_get() method in tools/fgt/get
+- Add CLI command fgt get cmdb firewall address
+- Add CLI command fgt get cmdb firewall addrgrp
+- Add CLI command fgt get cmdb firewall service-custom
+- Add CLI command fgt get cmdb firewall service-group
+- Add the layers of fotoobo into the architecture documentation
+- Support for Python3.13
+
+### Changed
+
+- Fix syslog format: we do not have to set PRI_VAL as it is calculated by SysLogHandler
+- Fix some typing issues for Python3.8
+- Optimize imports in CLI module
+- Upgrade requests, jinja, pygount and virtualenv due to security issues and bugs
+- Upgrade all dependencies to be up to date
+
+### Removed
+
 ## [2.2.0] - 2024-10-14
 
 ### Added

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,3 +1,6 @@
+
+## [2.3.0] - 2025-05-07
+
 ### Added
 
 - Add generic api_get() method in tools/fgt/get
@@ -17,4 +20,3 @@
 - Upgrade all dependencies to be up to date
 
 ### Removed
-

--- a/fotoobo/__init__.py
+++ b/fotoobo/__init__.py
@@ -8,4 +8,4 @@ to be extendable to your needs. It's most likely the swiss army knife for Fortin
 from .fortinet import FortiAnalyzer, FortiClientEMS, FortiGate, FortiManager
 
 __all__ = ["FortiAnalyzer", "FortiClientEMS", "FortiGate", "FortiManager"]
-__version__: str = "2.2.0"
+__version__: str = "2.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fotoobo"
-version = "2.2.0"
+version = "2.3.0"
 description = "The awesome Fortinet Toolbox"
 authors = ["Patrik Spiess <patrik.spiess@mgb.ch>", "Lukas Murer-Jäckle <lukas.murer@mgb.ch>"]
 readme = "README.md"


### PR DESCRIPTION
### Added

- Add generic api_get() method in tools/fgt/get
- Add CLI command fgt get cmdb firewall address
- Add CLI command fgt get cmdb firewall addrgrp
- Add CLI command fgt get cmdb firewall service-custom
- Add CLI command fgt get cmdb firewall service-group
- Add the layers of fotoobo into the architecture documentation
- Support for Python3.13

### Changed

- Fix syslog format: we do not have to set PRI_VAL as it is calculated by SysLogHandler
- Fix some typing issues for Python3.8
- Optimize imports in CLI module
- Upgrade requests, jinja, pygount and virtualenv due to security issues and bugs
- Upgrade all dependencies to be up to date
