### PR TITLE
👷 Add isort and reformat GitHub files

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+
       - name: Install poetry
         run: pip install poetry
+
       - name: Configure API token
         run: poetry config pypi-token.pypi "${{ secrets.PYPI_API_TOKEN }}"
+
       - name: Build and then publish fotoobo to PyPI
         run: poetry publish --build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,47 +11,58 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
+
       - name: Install poetry
-        run: |
-          pipx install poetry
+        run: pipx install poetry
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - run: poetry install --extras dev --extras docs
+
+      - name: Install the project with dev dependencies
+        run: poetry install --extras dev
+
+      - name: Check formatting with black
+        run: poetry run tox -e black
+
+      - name: Check imports with isort
+        run: poetry run tox -e isort
+
       - name: Analyzing the code with pylint
-        run: |
-          poetry run tox -e pylint
+        run: poetry run tox -e pylint
+
       - name: Type checking with mypy
-        run: |
-          poetry run tox -- -e mypy -- --junit-xml mypy.xml
+        run: poetry run tox -- -e mypy -- --junit-xml mypy.xml
+
       - name: Upload mypy report
         uses: actions/upload-artifact@v7
         with:
           name: mypy-report-${{ matrix.python-version }}
           path: mypy.xml
-      - name: Check formatting with black
-        run: |
-          poetry run tox -e black
-      - name: Unittests with pytest
-        run: |
-          poetry run tox -e pytest
+
+      - name: Unit-tests with pytest
+        run: poetry run tox -e pytest
 
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - name: Install poetry
-        run: |
-          pipx install poetry
+        run: pipx install poetry
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - run: poetry install --extras dev
+
+      - name: Install the project with dev dependencies
+        run: poetry install --extras dev
+
       - name: Check code coverage
-        run: |
-          poetry run tox -- -e coverage -- --cov-report=xml
+        run: poetry run tox -- -e coverage -- --cov-report=xml
+
       - name: Upload covearge report
         uses: actions/upload-artifact@v7
         with:
@@ -63,27 +74,29 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - name: Install poetry
-        run: |
-          pipx install poetry
-      - name: Check pyproject.toml
-        run: |
-          poetry check --strict
 
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Check pyproject.toml
+        run: poetry check --strict
 
   docs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
       - uses: actions/checkout@v6
+
       - name: Install poetry
-        run: |
-          pipx install poetry
+        run: pipx install poetry
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - run: poetry install --extras docs
+
+      - name: Install the project with docs dependencies
+        run: poetry install --extras docs
+
       - name: Create documentation
-        run: |
-          poetry run tox -e docs
+        run: poetry run tox -e docs

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,6 +1,10 @@
 ### Added
 
+- Add isort to organize and sort imports
+
 ### Changed
+
+- Reformat GitHub actions files
 
 ### Removed
 

--- a/fotoobo/cli/cloud/asset/get.py
+++ b/fotoobo/cli/cloud/asset/get.py
@@ -4,7 +4,7 @@ The FortiCloudAsset get commands
 
 import logging
 from pathlib import Path
-from typing import Any, Annotated
+from typing import Annotated, Any
 
 import typer
 

--- a/fotoobo/fortinet/fortigate_config.py
+++ b/fotoobo/fortinet/fortigate_config.py
@@ -4,7 +4,7 @@ The FortiGate configuration class represents the whole or parts of a FortiGate c
 
 import logging
 from pathlib import Path
-from typing import IO, Any
+from typing import Any, IO
 
 from fotoobo.exceptions import GeneralWarning
 from fotoobo.helpers.files import load_json_file, save_json_file

--- a/fotoobo/tools/fgt/cmdb/firewall/address.py
+++ b/fotoobo/tools/fgt/cmdb/firewall/address.py
@@ -5,7 +5,6 @@ FortiGate CMDB firewall address module
 from pathlib import Path
 from typing import Any
 
-
 from fotoobo.fortinet.fortigate import FortiGate
 from fotoobo.helpers.config import config
 from fotoobo.helpers.result import Result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,14 @@ docs = [
 [project.scripts]
 fotoobo = "fotoobo.main:main"
 
-# isort is used to organize-imports
+[tool.black]
+line-length = 100
+
 [tool.isort]
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
+profile = "black" 
+line_length = 100
+order_by_type = false
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = [
@@ -78,9 +83,6 @@ disable = [
     "too-few-public-methods"
 ]
 enable = [ "useless-suppression" ]
-
-[tool.black]
-line-length = 100
 
 [tool.mypy]
 strict=true
@@ -99,8 +101,22 @@ addopts = "--basetemp=tests/temp/"
 legacy_tox_ini = """[tox]
 
 isolated_build = True
-envlist = pylint, mypy, black, pytest, coverage, docs, stats
+envlist = black, isort, pylint, mypy, pytest, coverage, docs, stats
 testpaths = "tests"
+
+[testenv:black]
+description = Check formatting with black
+skip_install = true
+allowlist_externals = poetry, black
+commands_pre = poetry install
+commands = black --check --diff {posargs} .
+
+[testenv:isort]
+description = Check imports with isort
+skip_install = true
+allowlist_externals = poetry, isort
+commands_pre = poetry install
+commands = isort --check-only {posargs} .
 
 [testenv:pylint]
 description = Code analysis with pylint
@@ -115,13 +131,6 @@ skip_install = true
 allowlist_externals = poetry, mypy
 commands_pre = poetry install
 commands = mypy fotoobo tests {posargs}
-
-[testenv:black]
-description = Check formatting with black
-skip_install = true
-allowlist_externals = poetry, black
-commands_pre = poetry install
-commands = black --check --diff {posargs} .
 
 [testenv:pytest]
 description = do unit tests with pytest

--- a/tests/cli/ems/test_get.py
+++ b/tests/cli/ems/test_get.py
@@ -8,7 +8,7 @@ from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 from fotoobo.cli.main import app
-from tests.helper import ResponseMock, parse_help_output
+from tests.helper import parse_help_output, ResponseMock
 
 runner = CliRunner()
 

--- a/tests/cli/ems/test_monitor.py
+++ b/tests/cli/ems/test_monitor.py
@@ -8,7 +8,7 @@ from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 from fotoobo.cli.main import app
-from tests.helper import ResponseMock, parse_help_output
+from tests.helper import parse_help_output, ResponseMock
 
 runner = CliRunner()
 

--- a/tests/cli/faz/test_get.py
+++ b/tests/cli/faz/test_get.py
@@ -8,7 +8,7 @@ from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 from fotoobo.cli.main import app
-from tests.helper import ResponseMock, parse_help_output
+from tests.helper import parse_help_output, ResponseMock
 
 runner = CliRunner()
 

--- a/tests/cli/fgt/get/test_get.py
+++ b/tests/cli/fgt/get/test_get.py
@@ -8,7 +8,7 @@ from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 from fotoobo.cli.main import app
-from tests.helper import ResponseMock, parse_help_output
+from tests.helper import parse_help_output, ResponseMock
 
 runner = CliRunner()
 

--- a/tests/cli/fmg/test_get.py
+++ b/tests/cli/fmg/test_get.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 from fotoobo.cli.main import app
 from fotoobo.exceptions import GeneralError, GeneralWarning
-from tests.helper import ResponseMock, parse_help_output
+from tests.helper import parse_help_output, ResponseMock
 
 runner = CliRunner()
 


### PR DESCRIPTION
Now isort is used and enforced to organize imports in alphabetical order.
The GitHub actions are extended and a little bit reformatted.