### PR TITLE
Fix readthedocs deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,7 +23,7 @@ build:
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --extras docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 # Build documentation in the docs/source/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
After switching from installing with --with instead of --extras, we have also to change the readthedocs deplayment commands.